### PR TITLE
Fix typos

### DIFF
--- a/app/prism.js
+++ b/app/prism.js
@@ -123,7 +123,7 @@ var jstexts_en = {
 	helpline: '--- Please choose a service above ---',
 	route_btn_hint: 'Display a route to',
 	requestline: 'Request to',
-	resultline: 'Probalby accessed by these security services:',
+	resultline: 'Probably accessed by these security services:',
 	cable: 'submarine cable',
 	countries: {
 		"DE": {name: "Germany"},

--- a/app/tmpl/index.en.mustache
+++ b/app/tmpl/index.en.mustache
@@ -90,7 +90,7 @@
 	<div id="main" role="main">
 		<div id="text-intro">
 			<p class="lead">
-				Our visualisation shows examples of how internet packets,
+				Our visualization shows examples of how internet packets,
 				originated from Germany, wander around the internet cables while we use some of the most popular
 				internet services. Each country your data packets visit offers an opportunity for snooping. Please choose a service:
 			</p>

--- a/app/tmpl/index.en.mustache
+++ b/app/tmpl/index.en.mustache
@@ -34,7 +34,7 @@
 				'method="post"><fieldset id="embed-size" class="form-inline"><legend>Size</legend><label class="radio">'+
 				'<input type="radio" name="size" value="large" checked="checked"> Large (520&times;490)</label><label class="radio"><input type="radio" name="size" value="medium"> '+
 				'Medium (480&times;490)</label><label class="radio"><input type="radio" name="size" value="small"> Small (360&times;576)</label><label class="radio">'+
-				'</fieldset><fieldset class="form-inline"><legend>Language</legend><label class="radio"><input type="radio" name="lang" value="de" checked="checked"> German</label><label class="radio"><input type="radio" name="lang" value="en"> English</label></fieldset><h2>Code</h2><p>Copy this code to youzr website:</p><code id="embed-code"></code></form><p><a href="javascript:;" class="btn btn-medium btn-primary">Close</a></p></div></div>';
+				'</fieldset><fieldset class="form-inline"><legend>Language</legend><label class="radio"><input type="radio" name="lang" value="de" checked="checked"> German</label><label class="radio"><input type="radio" name="lang" value="en"> English</label></fieldset><h2>Code</h2><p>Copy this code to your website:</p><code id="embed-code"></code></form><p><a href="javascript:;" class="btn btn-medium btn-primary">Close</a></p></div></div>';
 	</script>
 
 	<!-- polyfills -->
@@ -105,7 +105,7 @@
 				It is using one of the basic Internet Protocols (IP): Asking every IP-router
 				(think of it as a switchboard), which is forwarding a packet, about its identity.
 				Not every router is answering to Traceroute and which cable is used, we don't know.
-				Depening if it's day or night, the packets can take pretty diffent routes.
+				Depending if it's day or night, the packets can take pretty different routes.
 			</p>
 			<p>
 				In the end, the connections we are displaying in this app (in slow motion) are the most telling
@@ -121,7 +121,7 @@
 			<p>
 				This App can be embedded
 				(<a href="//creativecommons.org/licenses/by/3.0/" class="license-cc-by">CC BY</a>) and is
-				also avaiable <a href="/prism/de">in German</a>.
+				also available <a href="/prism/de">in German</a>.
 			</p>
 		</div>
 	</div>

--- a/app/tmpl/index.en.mustache
+++ b/app/tmpl/index.en.mustache
@@ -90,9 +90,9 @@
 	<div id="main" role="main">
 		<div id="text-intro">
 			<p class="lead">
-				Our visualization shows examples of how internet packets,
-				originated from Germany, wander around the internet cables while we use some of the most popular
-				internet services. Each country your data packets visit offers an opportunity for snooping. Please choose a service:
+				Our visualization shows examples of how Internet packets,
+				originated from Germany, wander around the Internet cables while we use some of the most popular
+				Internet services. Each country your data packets visit offers an opportunity for snooping. Please choose a service:
 			</p>
 		</div>
 		<div id="app">
@@ -101,7 +101,7 @@
 		<div id="text-sub">
 			<p>
 				The cable routes on the map are taken from <a href="http://cablemap.info">cablemap.info</a>. We determined how
-				packets are traveling through the internet by using the program <a href="http://en.wikipedia.org/wiki/Traceroute">Traceroute</a>.
+				packets are traveling through the Internet by using the program <a href="http://en.wikipedia.org/wiki/Traceroute">Traceroute</a>.
 				It is using one of the basic Internet Protocols (IP): Asking every IP-router
 				(think of it as a switchboard), which is forwarding a packet, about its identity.
 				Not every router is answering to Traceroute and which cable is used, we don't know.


### PR DESCRIPTION
I fixed a few typos in the English version. Furthermore, I changed “visualisation” (British English) to “visualization” (American English) and capitalized all occurrences of “Internet” (as it was sometimes capitalized, sometimes lowercased).
