### PR TITLE
Call map.panTo() only once on first hop

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -52,7 +52,6 @@ RaPath.prototype = {
 		this.geotrace = geotrace;
 		this.layers = [];
 		info.append(texts.requestline + ' ' + geotrace.name);
-		map.panTo(this.geotrace.hops[0].p);
 		this.processStep(0);
 	},
 	processStep: function (index) {


### PR DESCRIPTION
`map.panTo` was called twice on the first hop, once on [line 55](https://github.com/opendatacity/prism/blob/3b09fb00bdad4c1077616118699b4b64aa2d417a/assets/js/index.js#L55) and immediately after on [line 62](https://github.com/opendatacity/prism/blob/3b09fb00bdad4c1077616118699b4b64aa2d417a/assets/js/index.js#L62).

For me, this sometimes caused the initial map pan not to trigger at all, it would only start panning on the second hop then. Calling `map.panTo` only once seems to fix this behavior.
